### PR TITLE
Feature/rr 223 setup api endpoint to receive latest income details

### DIFF
--- a/app/controllers/admin/rebate_forms_controller.rb
+++ b/app/controllers/admin/rebate_forms_controller.rb
@@ -48,16 +48,8 @@ class Admin::RebateFormsController < Admin::BaseController
 
   # PATCH/PUT /admin/rebate_forms/1
   def update
-    # updating attachments
-    if params.fetch(:rebate_form, {}).fetch(:attachments, false)
-      @rebate_form.update(rebate_form_params)
-    # updating rebate form itself
-    elsif params.fetch(:rebate_form, false)
-      # update the fields (preserves the other elements of the hash)
-      @rebate_form.fields.update(rebate_form_fields_params)
-      @rebate_form.updated_by = current_user.id
-      @rebate_form.save && @rebate_form.calc_rebate_amount!
-    end
+    @rebate_form = RebateFormsService.new(rebate_form_fields_params).update
+    @rebate_form.update(updated_by: current_user.id)
     respond_with @rebate_form, location: admin_rebate_form_url(@rebate_form), notice: 'Rebate form was successfully updated.'
   end
 
@@ -79,9 +71,7 @@ class Admin::RebateFormsController < Admin::BaseController
   end
 
   def rebate_form_fields_params
-    params.require(:rebate_form).permit(
-      fields: %i[full_name income dependants lived_here_before_july_2017 lived_here_before_july_2018]
-    )['fields']
+    params.permit(:id, :valuation_id, :total_rates, :location, rebate_form: { fields: {} })
   end
 
   def rebate_form_params

--- a/app/controllers/rebate_forms_controller.rb
+++ b/app/controllers/rebate_forms_controller.rb
@@ -13,9 +13,7 @@ class RebateFormsController < ApiController
   end
 
   def create
-    rebate_form = RebateForm.create(rebate_form_params)
-    rebate_form.calc_rebate_amount!
-    raise 'No rebate calculated. This should never happen' if rebate_form.rebate.blank?
+    rebate_form = RebateFormsService.new(rebate_form_params).update
 
     if rebate_form.errors.any?
       render_errors_for(rebate_form)
@@ -25,8 +23,8 @@ class RebateFormsController < ApiController
   end
 
   def update
-    rebate_form = RebateForm.find_by(token: params[:id])
-    rebate_form.update(rebate_form_params)
+    rebate_form = RebateFormsService.new(rebate_form_params).update
+
     if rebate_form.errors.any?
       render_errors_for(rebate_form)
     else
@@ -35,6 +33,14 @@ class RebateFormsController < ApiController
   end
 
   def rebate_form_params
-    params.require(:api).require(:data).require(:attributes).permit(:valuation_id, fields: {})
+    params
+      .require(:api)
+      .require(:data)
+      .require(:attributes)
+      .permit(:id,
+              :valuation_id,
+              :total_rates,
+              :location,
+              fields: {})
   end
 end

--- a/app/helpers/rebate_forms_helper.rb
+++ b/app/helpers/rebate_forms_helper.rb
@@ -15,9 +15,10 @@ module RebateFormsHelper
     "$#{format('%.2f', rebate_form.rebate)}"
   end
 
-  def rebate_form_total(rebate_form)
-    "$#{format('%.2f', rebate_form.fields['income'])}"
-  end
+  # commenting this out until Mischa's code lands
+  # def rebate_form_total(rebate_form)
+  #   "$#{format('%.2f', rebate_form.fields['income'])}"
+  # end
 
   def rebate_form_lived_year?(rebate_form)
     if rebate_form.lived_here.present?

--- a/app/models/rebate_form.rb
+++ b/app/models/rebate_form.rb
@@ -16,7 +16,6 @@ class RebateForm < ApplicationRecord
   validates :rebate, presence: true
   validates :property, presence: true
 
-  validate :required_fields_present
   validate :same_council
   validate :only_completed_forms_in_batch
 
@@ -97,12 +96,6 @@ class RebateForm < ApplicationRecord
 
   def mailer
     RebateFormsMailer.with(rebate_form: self)
-  end
-
-  def required_fields_present
-    %w[income dependants full_name].each do |field|
-      errors.add(:fields, "must include #{field}") if fields[field].blank?
-    end
   end
 
   def same_council

--- a/app/services/rebate_forms_service.rb
+++ b/app/services/rebate_forms_service.rb
@@ -33,11 +33,14 @@ class RebateFormsService
   def update_rebate_form(property)
     rebate_form = RebateForm.find_by(id: @id)
     property = rebate_form.property if property.id.nil?
-    new_fields = @update_fields unless @update_fields.nil?
-    new_fields = {} if @update_fields.nil?
-    fields_to_update = rebate_form.fields.merge(new_fields)
+    fields_to_update = rebate_form.fields.merge(merged_fields)
     rebate_form.update(property: property, valuation_id: property.valuation_id, fields: fields_to_update)
     rebate_form
+  end
+
+  def merged_fields
+    return @update_fields unless @update_fields.nil?
+    {}
   end
 
   def create_rebate_form(property)

--- a/app/services/rebate_forms_service.rb
+++ b/app/services/rebate_forms_service.rb
@@ -29,7 +29,8 @@ class RebateFormsService
   def update_rebate_form(property)
     rebate_form = RebateForm.find_by(id: @id)
     property = rebate_form.property if property.id.nil?
-    rebate_form.update(property: property, valuation_id: property.valuation_id, fields: @update_fields)
+    rebate_form.update(property: property, valuation_id: property.valuation_id)
+    rebate_form.fields.update(@update_fields) unless @update_fields.nil?
     rebate_form
   end
 

--- a/app/services/rebate_forms_service.rb
+++ b/app/services/rebate_forms_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class RebateFormsService
+  def initialize(rebate_form_attributes)
+    @id = rebate_form_attributes[:id]
+    @valuation_id = rebate_form_attributes[:valuation_id]
+    @create_fields = rebate_form_attributes[:fields]
+    @update_fields = rebate_form_attributes[:rebate_form][:fields] if rebate_form_attributes[:rebate_form]
+    @location = rebate_form_attributes[:location]
+    @total_rates = rebate_form_attributes[:total_rates]
+  end
+
+  def update
+    property = create_or_update_property
+    rebate_form = create_or_update_rebate_form(property)
+    update_rates_bill(property)
+    rebate_form.calc_rebate_amount!
+    raise 'No rebate calculated. This should never happen' if rebate_form.rebate.blank?
+    rebate_form
+  end
+
+  private
+
+  def create_or_update_rebate_form(property)
+    return update_rebate_form(property) if @id
+    create_rebate_form(property)
+  end
+
+  def update_rebate_form(property)
+    rebate_form = RebateForm.find_by(id: @id)
+    property = rebate_form.property if property.id.nil?
+    rebate_form.update(property: property, valuation_id: property.valuation_id, fields: @update_fields)
+    rebate_form
+  end
+
+  def create_rebate_form(property)
+    RebateForm.create(property: property,
+                      valuation_id: property.valuation_id,
+                      fields: @create_fields)
+  end
+
+  def create_or_update_property
+    Property.find_or_create_by(valuation_id: @valuation_id,
+                               location: @location,
+                               rating_year: ENV['YEAR'])
+  end
+
+  def update_rates_bill(property)
+    RatesBill.find_or_create_by(property: property,
+                                rating_year: property.rating_year,
+                                total_rates: @total_rates)
+  end
+end

--- a/app/services/rebate_forms_service.rb
+++ b/app/services/rebate_forms_service.rb
@@ -2,16 +2,7 @@
 
 class RebateFormsService
   def initialize(rebate_form_attributes)
-    @id = rebate_form_attributes['id']
-    @valuation_id = rebate_form_attributes['valuation_id']
-    @create_fields = rebate_form_attributes['fields']
-    @update_fields = if rebate_form_attributes['rebate_form']
-                       rebate_form_attributes['rebate_form']['fields']
-                     else
-                       @create_fields
-                     end
-    @location = rebate_form_attributes['location']
-    @total_rates = rebate_form_attributes['total_rates']
+    @rebate_form_attributes = rebate_form_attributes
   end
 
   def update
@@ -26,38 +17,43 @@ class RebateFormsService
   private
 
   def create_or_update_rebate_form(property)
-    return update_rebate_form(property) if @id
+    return update_rebate_form(property) if @rebate_form_attributes['id']
     create_rebate_form(property)
   end
 
   def update_rebate_form(property)
-    rebate_form = RebateForm.find_by(id: @id)
+    rebate_form = RebateForm.find_by(id: @rebate_form_attributes['id'])
     property = rebate_form.property if property.id.nil?
-    fields_to_update = rebate_form.fields.merge(merged_fields)
+    fields_to_update = rebate_form.fields.merge(fields_to_merge)
     rebate_form.update(property: property, valuation_id: property.valuation_id, fields: fields_to_update)
     rebate_form
   end
 
-  def merged_fields
-    return @update_fields unless @update_fields.nil?
+  def update_fields
+    return @rebate_form_attributes['rebate_form']['fields'] if @rebate_form_attributes['rebate_form']
+    @rebate_form_attributes['fields']
+  end
+
+  def fields_to_merge
+    return update_fields unless update_fields.nil?
     {}
   end
 
   def create_rebate_form(property)
     RebateForm.create(property: property,
                       valuation_id: property.valuation_id,
-                      fields: @create_fields)
+                      fields: @rebate_form_attributes['fields'])
   end
 
   def create_or_update_property
-    Property.find_or_create_by(valuation_id: @valuation_id,
-                               location: @location,
+    Property.find_or_create_by(valuation_id: @rebate_form_attributes['valuation_id'],
+                               location: @rebate_form_attributes['location'],
                                rating_year: ENV['YEAR'])
   end
 
   def update_rates_bill(property)
     RatesBill.find_or_create_by(property: property,
                                 rating_year: property.rating_year,
-                                total_rates: @total_rates)
+                                total_rates: @rebate_form_attributes['total_rates'])
   end
 end

--- a/app/services/rebate_forms_service.rb
+++ b/app/services/rebate_forms_service.rb
@@ -2,12 +2,16 @@
 
 class RebateFormsService
   def initialize(rebate_form_attributes)
-    @id = rebate_form_attributes[:id]
-    @valuation_id = rebate_form_attributes[:valuation_id]
-    @create_fields = rebate_form_attributes[:fields]
-    @update_fields = rebate_form_attributes[:rebate_form][:fields] if rebate_form_attributes[:rebate_form]
-    @location = rebate_form_attributes[:location]
-    @total_rates = rebate_form_attributes[:total_rates]
+    @id = rebate_form_attributes['id']
+    @valuation_id = rebate_form_attributes['valuation_id']
+    @create_fields = rebate_form_attributes['fields']
+    @update_fields = if rebate_form_attributes['rebate_form']
+                       rebate_form_attributes['rebate_form']['fields']
+                     else
+                       @create_fields
+                     end
+    @location = rebate_form_attributes['location']
+    @total_rates = rebate_form_attributes['total_rates']
   end
 
   def update
@@ -29,8 +33,10 @@ class RebateFormsService
   def update_rebate_form(property)
     rebate_form = RebateForm.find_by(id: @id)
     property = rebate_form.property if property.id.nil?
-    rebate_form.update(property: property, valuation_id: property.valuation_id)
-    rebate_form.fields.update(@update_fields) unless @update_fields.nil?
+    new_fields = @update_fields unless @update_fields.nil?
+    new_fields = {} if @update_fields.nil?
+    fields_to_update = rebate_form.fields.merge(new_fields)
+    rebate_form.update(property: property, valuation_id: property.valuation_id, fields: fields_to_update)
     rebate_form
   end
 

--- a/spec/controllers/admin/rebate_forms_controller_spec.rb
+++ b/spec/controllers/admin/rebate_forms_controller_spec.rb
@@ -131,12 +131,10 @@ RSpec.describe Admin::RebateFormsController, type: :controller do
     end
 
     describe 'Editing rebate_forms' do
-      let(:attachment_params) do
-        { attachments: [
-          tempfile: Rails.root.join('sig.png'),
-          original_filename: 'sig.png',
-          content_type: 'image/jpeg'
-        ] }
+      let(:params) do
+        {
+          fields: { full_name: 'Mary Jane Kelly', 'dependants': 9, income: 11_999 }
+        }
       end
 
       shared_examples 'controller works' do
@@ -145,7 +143,7 @@ RSpec.describe Admin::RebateFormsController, type: :controller do
       end
 
       context 'with valid params' do
-        before { put :update, params: { id: rebate_form.to_param, rebate_form: attachment_params } }
+        before { put :update, params: { id: rebate_form.to_param, rebate_form: params } }
 
         include_examples 'controller works'
       end
@@ -163,7 +161,7 @@ RSpec.describe Admin::RebateFormsController, type: :controller do
 
         it 'does not allow changes to completed rebate_form' do
           expect do
-            put :update, params: { id: rebate_form.to_param, rebate_form: attachment_params }
+            put :update, params: { id: rebate_form.to_param, rebate_form: params }
           end.not_to change(rebate_form, :valuation_id)
         end
       end

--- a/spec/factories/rebate_forms.rb
+++ b/spec/factories/rebate_forms.rb
@@ -5,7 +5,20 @@ FactoryBot.define do
     valuation_id { Faker::Vehicle.vin }
     property { Property.find_by(valuation_id: valuation_id, rating_year: ENV['YEAR']) }
     # token <-- auto generated. Don't set in factory
-    fields { { "full_name": 'Fred', "income": 0, dependants: 0 } }
+    fields do
+      { full_name: 'Hermione Granger',
+        dependants: 0,
+        customer_id: 123,
+        phone: '0212345678',
+        income: {},
+        email: 'hermione.granger@hogwarts.com',
+        has_partner: true,
+        occupation: 'witch',
+        fifty_percent_claimed: true,
+        moved_within_rating_year: false,
+        lived_in_property_july_1: true,
+        details_of_previous_property: '123 Muggle Lane, Hogsmead, England' }
+    end
     completed { false }
     rebate { 555.12 }
     batch { nil }

--- a/spec/features/admin/rebate_forms/index_spec.rb
+++ b/spec/features/admin/rebate_forms/index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'RebateForm', type: :feature do
 
     it ' Can see rebate forms' do
       visit '/admin/rebate_forms'
-      fill_in 'name', with: 'Fred'
+      fill_in 'name', with: rebate_form.fields['full_name']
       click_button 'SEARCH'
       expect(page).to have_text(rebate_form.fields['full_name'])
 
@@ -36,7 +36,7 @@ RSpec.describe 'RebateForm', type: :feature do
 
     it ' Can see rebate forms' do
       visit '/admin/rebate_forms'
-      fill_in 'name', with: 'Fred'
+      fill_in 'name', with: rebate_form.fields['full_name']
       click_button 'SEARCH'
       expect(page).to have_text(rebate_form.fields['full_name'])
 

--- a/spec/helpers/rebate_forms_helper_spec.rb
+++ b/spec/helpers/rebate_forms_helper_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RebateFormsHelper, type: :helper do
     it { expect(rebate_form_amount(rebate_form)).to eq '$555.12' }
   end
 
-  describe 'rebate_form_total(rebate_form)' do
+  pending 'rebate_form_total(rebate_form)' do
     it { expect(rebate_form_total(rebate_form)).to eq '$0.00' }
   end
 

--- a/spec/services/rebate_forms_service_spec.rb
+++ b/spec/services/rebate_forms_service_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RebateFormsService do
+  pending 'new rebate form' do
+    # these will not pass until the calulator is working
+    let(:create_params) do
+      {
+        'valuation_id': '12345',
+        'total_rates': '12345',
+        'location': 'This is the address',
+        'fields': {
+          'full_name': 'Herminone Granger',
+          'customer_id': '12345',
+          'phone': '022123-4567',
+          'email': 'hermione.granger@hogwarts.com',
+          'partner': 'string string string',
+          'dependants': '0',
+          'occupation': 'witch',
+          '50_percent_claimed': 'true',
+          'moved_within_rating_year': 'false',
+          'lived_in_property_july_1': 'true',
+          'details_of_previous_property': 'string string string',
+          'income': {}
+        }
+      }
+    end
+
+    subject { described_class.new(create_params) }
+
+    describe '#update' do
+      context 'with valid params' do
+        it 'creates a new rebate form' do
+          subject.update
+          expect(RebateForm.count).to eq 1
+        end
+      end
+    end
+  end
+
+  describe 'existing rebate form' do
+    let!(:property) { FactoryBot.create(:property_with_rates) }
+    let!(:property2) { FactoryBot.create(:property_with_rates) }
+    let!(:rebate_form) { FactoryBot.create(:rebate_form, valuation_id: property.valuation_id, property: property) }
+    let(:update_params) do
+      {
+        'id' => rebate_form.id,
+        'valuation_id' => property2.valuation_id,
+        'total_rates' => '12345',
+        'location' => property2.location,
+        'rebate_form' => {
+          'fields' => {
+            'full_name' => 'Best Witch',
+            'customer_id' => '12345',
+            'phone' => '022123-4567',
+            'email' => 'hermione.granger@potterworld.com',
+            'has_partner' => 'true',
+            'dependants' => '3',
+            'occupation' => 'witch',
+            '50_percent_claimed' => 'true',
+            'income' => {}
+          }
+        }
+      }
+    end
+
+    subject { described_class.new(update_params) }
+
+    describe '#update' do
+      context 'with valid params' do
+        it 'updates a rebate form' do
+          subject.update
+          expect(RebateForm.first.reload.fields['full_name']).to eq 'Best Witch'
+          expect(RebateForm.first.reload.fields['email']).to eq 'hermione.granger@potterworld.com'
+          expect(RebateForm.first.reload.fields['dependants']).to eq '3'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a pretty big change to the api - it allows both the api Rebate Forms Controller and admin Rebate Forms Controller to receive all of the fields that we need.

There is a new service to handle both creating and updating rebate_forms, and tests have been updated to work with this. I've also done manual tests using Postman and a local dev environment to ensure that it is working.

Some things to note:
- the calculator isn't working so testing could only be done to a point
- only one working test has been added for the new service - these should be added to to handle edge cases
- a helper method was marked commented out and it's test marked as the code it refers to will be changing once @mischa-s 's work lands.