### PR TITLE
Feature/rr 223 setup api endpoint to receive latest income details

### DIFF
--- a/app/controllers/admin/rebate_forms_controller.rb
+++ b/app/controllers/admin/rebate_forms_controller.rb
@@ -71,7 +71,7 @@ class Admin::RebateFormsController < Admin::BaseController
   end
 
   def rebate_form_fields_params
-    params.permit(:id, :valuation_id, :total_rates, :location, rebate_form: { fields: {} })
+    params.permit(:id, :valuation_id, :total_rates, :location, :council, rebate_form: { fields: {} })
   end
 
   def rebate_form_params

--- a/app/controllers/rebate_forms_controller.rb
+++ b/app/controllers/rebate_forms_controller.rb
@@ -39,6 +39,7 @@ class RebateFormsController < ApiController
       .require(:attributes)
       .permit(:id,
               :valuation_id,
+              :council,
               :total_rates,
               :location,
               fields: {})

--- a/app/services/rebate_forms_service.rb
+++ b/app/services/rebate_forms_service.rb
@@ -6,7 +6,8 @@ class RebateFormsService
   end
 
   def update
-    property = create_or_update_property
+    council = create_or_update_council
+    property = create_or_update_property(council)
     rebate_form = create_or_update_rebate_form(property)
     update_rates_bill(property)
     rebate_form.calc_rebate_amount!
@@ -45,10 +46,15 @@ class RebateFormsService
                       fields: @rebate_form_attributes['fields'])
   end
 
-  def create_or_update_property
+  def create_or_update_property(council)
     Property.find_or_create_by(valuation_id: @rebate_form_attributes['valuation_id'],
                                location: @rebate_form_attributes['location'],
-                               rating_year: ENV['YEAR'])
+                               rating_year: ENV['YEAR'],
+                               council: council)
+  end
+
+  def create_or_update_council
+    Council.find_by(name: @rebate_form_attributes['council'])
   end
 
   def update_rates_bill(property)

--- a/app/services/rebate_forms_service.rb
+++ b/app/services/rebate_forms_service.rb
@@ -6,7 +6,7 @@ class RebateFormsService
   end
 
   def update
-    council = create_or_update_council
+    council = find_council
     property = create_or_update_property(council)
     rebate_form = create_or_update_rebate_form(property)
     update_rates_bill(property)
@@ -53,7 +53,7 @@ class RebateFormsService
                                council: council)
   end
 
-  def create_or_update_council
+  def find_council
     Council.find_by(name: @rebate_form_attributes['council'])
   end
 

--- a/spec/services/rebate_forms_service_spec.rb
+++ b/spec/services/rebate_forms_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RebateFormsService do
         'valuation_id': '12345',
         'total_rates': '12345',
         'location': 'This is the address',
+        'council': 'Wellington City Council',
         'fields': {
           'full_name': 'Herminone Granger',
           'customer_id': '12345',
@@ -49,6 +50,7 @@ RSpec.describe RebateFormsService do
         'valuation_id' => property2.valuation_id,
         'total_rates' => '12345',
         'location' => property2.location,
+        'council' => property2.council.name,
         'rebate_form' => {
           'fields' => {
             'full_name' => 'Best Witch',
@@ -74,6 +76,7 @@ RSpec.describe RebateFormsService do
           expect(RebateForm.first.reload.fields['full_name']).to eq 'Best Witch'
           expect(RebateForm.first.reload.fields['email']).to eq 'hermione.granger@potterworld.com'
           expect(RebateForm.first.reload.fields['dependants']).to eq '3'
+          expect(RebateForm.first.reload.property.council.name).to eq property2.council.name
         end
       end
     end


### PR DESCRIPTION
This PR adds a council to the expected params so that a property can be properly created if it doesn't yet exist. It assumes that the proper list of councils will exist in the DB. The test has been updated to expect council.